### PR TITLE
リンク先を再設定

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <header>
-    <a href="/" class="icon">StreamTube</a>
+    <a href="https://github.com/portfoliokns/StreamTube" class="icon">StreamTube</a>
   </header>
 
   <div class="main">


### PR DESCRIPTION
# What
StreamTubeのリポジトリページ（ReadMeが読める）へ遷移できるように修正

# Why
本番環境を確認すると、アイコンをクリックすると、404に通じていたため