### PR TITLE
名称やパスを変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   - ダウンロード機能
 - Wayback検索
 
-※状況に応じて、機能をアップデートしていく予定です。
+※当面、新規機能のアップデートはありません。
 
 # 各種機能について
 ## トップページについて
@@ -43,7 +43,7 @@ Wayback Machine上にyoutubeの動画が存在するかどうかを検索する�
 - PCとブラウザ（Google Chrome）をご用意ください。
 - 視聴したい動画のURLを準備してください。
 - 次のURLへアクセスしてください。
-https://portfoliokns.github.io/StreamTube/
+https://portfoliokns.github.io/StreetTube/
 
 # 使い方
 ## 基本操作について

--- a/index.html
+++ b/index.html
@@ -6,19 +6,19 @@
   <link rel="stylesheet" href="style.css">
   <script src="script.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
-  <title>StreamTube</title>
+  <title>StreetTube</title>
   
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 
@@ -29,6 +29,8 @@
           おしらせ一覧
         </div>
         <div class="news_box">
+          <div class="sentence">2024/12/7 【重要なお知らせ】今後、このアプリケーションの新規機能のアップデートは当面ありません。</div>
+          <div class="sentence">2024/12/7 【重要なお知らせ】Webアプリケーションとしての名称やパスなどを"StreetTube"に変更しました。</div>
           <div class="sentence">2024/10/6 Wayback検索を提供開始。</div>
           <div class="sentence">2024/10/4 連続キャプチャ機能を提供開始。</div>
           <div class="sentence">2024/9/30 エクスポート/インポート機能を提供開始。</div>

--- a/templates/capture.html
+++ b/templates/capture.html
@@ -11,14 +11,14 @@
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 

--- a/templates/captures.html
+++ b/templates/captures.html
@@ -12,14 +12,14 @@
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 

--- a/templates/clipplayer.html
+++ b/templates/clipplayer.html
@@ -9,19 +9,19 @@
   <script src="../static/js/share.js"></script>
   <script src="../static/js/clipplayer.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
-  <title>StreamTube</title>
+  <title>StreetTube</title>
   
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 

--- a/templates/multiplayer.html
+++ b/templates/multiplayer.html
@@ -9,19 +9,19 @@
   <script src="../static/js/share.js"></script>
   <script src="../static/js/multiplayer.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
-  <title>StreamTube</title>
+  <title>StreetTube</title>
   
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 

--- a/templates/waybackmachine.html
+++ b/templates/waybackmachine.html
@@ -7,19 +7,19 @@
   <link rel="stylesheet" href="../static/css/waybackmachine.css">
   <script src="../static/js/share.js"></script>
   <script src="../static/js/waybackmachine.js"></script>
-  <title>StreamTube</title>
+  <title>StreetTube</title>
   
 </head>
 <body>
   <header>
-    <a href="/StreamTube/" class="icon">StreamTube</a>
+    <a href="/StreetTube/" class="icon">StreetTube</a>
     <div class="header_links">
-      <a href="/StreamTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
-      <a href="/StreamTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
-      <a href="/StreamTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
-      <a href="/StreamTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
-      <a href="/StreamTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
-      <a href="https://github.com/portfoliokns/StreamTube" class="header_link">About</a>
+      <a href="/StreetTube/templates/multiplayer.html" class="header_link">マルチ視聴</a>
+      <a href="/StreetTube/templates/clipplayer.html" class="header_link">クリップ視聴</a>
+      <a href="/StreetTube/templates/capture.html" class="header_link" target="_blank">キャプチャ機能</a>
+      <a href="/StreetTube/templates/captures.html" class="header_link" target="_blank">連続キャプチャ機能</a>
+      <a href="/StreetTube/templates/waybackmachine.html" class="header_link">Wayback検索</a>
+      <a href="https://github.com/portfoliokns/StreetTube" class="header_link">About</a>
     </div>
   </header>
 


### PR DESCRIPTION
# What
名称を"SteamTube"から"StreetTube"に変更

# Why
"SteamTube"という名称はすでに別のサービスとして稼働していたため、名称の変更を迫られていた。

# 補足
これに伴い、今後このサービスの新規機能のアップデートはない。
また汎用性が低く、機能拡張が困難なためであり、現在はchromeの拡張機能の開発に注力しているため。
